### PR TITLE
add sg read tests

### DIFF
--- a/test/sg.test.js
+++ b/test/sg.test.js
@@ -1,0 +1,308 @@
+const { assert } = require("chai");
+const { checkSgStatus, handleSgResults } = require("../src");
+
+describe("Test read subgraph", async function () {
+    it("should check subgraph status", async function () {
+        sgsUrls = [
+            "url1",
+            "url2"
+        ];
+        const blockNumberResult = {
+            status: "fulfilled",
+            reason: undefined,
+            value: 123
+        };
+        const mockSgStatusOk = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: false,
+                                block: { number: 123 }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: false,
+                                block: { number: 122 }
+                            }
+                        }
+                    }
+                }
+            }
+        ];
+        let result;
+        try {
+            result = checkSgStatus(sgsUrls, mockSgStatusOk, blockNumberResult);
+        } catch {
+            throw "expected to resolve, but rejected";
+        }
+        assert.deepEqual(result.availableSgs, sgsUrls);
+        assert.deepEqual(result.reasons, {});
+
+        const mockSgStatusRejected = [
+            {
+                status: "rejected",
+                reason: undefined,
+                value: undefined
+            },
+            {
+                status: "rejected",
+                reason: undefined,
+                value: undefined
+            }
+        ];
+        try {
+            checkSgStatus(sgsUrls, mockSgStatusRejected, blockNumberResult);
+            throw "expected to reject, but resolved";
+        } catch(error) {
+            assert.equal(error, "unhealthy subgraph");
+        }
+
+        const mockSgStatusUndefined = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: undefined
+            },
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: undefined
+            }
+        ];
+        try {
+            checkSgStatus(sgsUrls, mockSgStatusUndefined, blockNumberResult);
+            throw "expected to reject, but resolved";
+        } catch(error) {
+            assert.equal(error, "unhealthy subgraph");
+        }
+
+        const mockSgStatusUndefinedPartial = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: false,
+                                block: { number: 123 }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: undefined
+            }
+        ];
+        try {
+            result = checkSgStatus(sgsUrls, mockSgStatusUndefinedPartial, blockNumberResult);
+        } catch(error) {
+            throw "expected to resolve, but rejected";
+        }
+        assert.deepEqual(result.reasons, { "url2": "did not receive valid status response" });
+        assert.deepEqual(result.availableSgs, ["url1"]);
+
+
+        const mockSgStatusIndexingError = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: true,
+                                block: { number: 123 }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: false,
+                                block: { number: 123 }
+                            }
+                        }
+                    }
+                }
+            }
+        ];
+        try {
+            result = checkSgStatus(sgsUrls, mockSgStatusIndexingError, blockNumberResult);
+        } catch(error) {
+            throw "expected to resolve, but rejected";
+        }
+        assert.deepEqual(result.reasons, { "url1": "subgraph has indexing error" });
+        assert.deepEqual(result.availableSgs, ["url2"]);
+
+        const mockSgStatusOutOfSync = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: false,
+                                block: { number: 12 }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            _meta: {
+                                hasIndexingErrors: false,
+                                block: { number: 123 }
+                            }
+                        }
+                    }
+                }
+            }
+        ];
+        try {
+            result = checkSgStatus(sgsUrls, mockSgStatusOutOfSync, blockNumberResult);
+        } catch(error) {
+            throw "expected to resolve, but rejected";
+        }
+        assert.deepEqual(result.reasons, { "url1": "possibly out of sync" });
+        assert.deepEqual(result.availableSgs, ["url2"]);
+
+    });
+
+    it("should return correct orders details", async function () {
+        sgsUrls = [
+            "url1",
+            "url2"
+        ];
+        const mockSgResultOk = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            orders: [
+                                "order1",
+                                "order2"
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            orders: [
+                                "order3",
+                                "order4"
+                            ]
+                        }
+                    }
+                }
+            }
+        ];
+        let result;
+        try {
+            result = handleSgResults(sgsUrls, mockSgResultOk);
+        } catch {
+            throw "expected to resolve, but rejected";
+        }
+        assert.deepEqual(result, ["order1", "order2", "order3", "order4"]);
+
+        const mockSgResultRejected = [
+            {
+                status: "rejected",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            orders: [
+                                "order1",
+                                "order2"
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                status: "rejected",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            orders: [
+                                "order3",
+                                "order4"
+                            ]
+                        }
+                    }
+                }
+            }
+        ];
+        try {
+            handleSgResults(sgsUrls, mockSgResultRejected);
+            throw "expected to resolve, but rejected";
+        } catch(error) {
+            assert.equal(error, "could not get order details from given sgs");
+        }
+
+        const mockSgResultPartial = [
+            {
+                status: "fulfilled",
+                reason: undefined,
+                value: {
+                    data: {
+                        data: {
+                            orders: [
+                                "order1",
+                                "order2"
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                status: "rejected",
+                reason: undefined,
+                value: undefined
+            }
+        ];
+        try {
+            result = handleSgResults(sgsUrls, mockSgResultPartial);
+        } catch {
+            throw "expected to resolve, but rejected";
+        }
+        assert.deepEqual(result, ["order1", "order2"]);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
resolves #88 
and adding tests for them
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
query subgraph `_meta` field for `hasIndexingError` before reading tfor orders, and decide based on the status result, as well as forward the results to otel for setting alarms when an sg is not working properly
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
