### PR TITLE
fix handle io key difference from sg json order vs contract abi

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1478,7 +1478,7 @@ const bundleOrders = (
         const orderDetails = ordersDetails[i];
         const orderStruct = JSON.parse(ordersDetails[i].orderJSONString);
         // exchange the "handleIo" to "handleIO" in case "handleIO" is not present in order json
-        if (orderStruct.handleIO === undefined) {
+        if (!("handleIO" in orderStruct)) {
             orderStruct.handleIO = orderStruct.handleIo;
             delete orderStruct.handleIo;
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1477,9 +1477,11 @@ const bundleOrders = (
     for (let i = 0; i < ordersDetails.length; i++) {
         const orderDetails = ordersDetails[i];
         const orderStruct = JSON.parse(ordersDetails[i].orderJSONString);
-        // exchange the "handleIo" to "handleIO"
-        orderStruct.handleIO = orderStruct.handleIo;
-        delete orderStruct.handleIo;
+        // exchange the "handleIo" to "handleIO" in case "handleIO" is not present in order json
+        if (orderStruct.handleIO === undefined || orderStruct.handleIO === null) {
+            orderStruct.handleIO = orderStruct.handleIo;
+            delete orderStruct.handleIo;
+        }
         for (let j = 0; j < orderStruct.validOutputs.length; j++) {
             const _output = orderStruct.validOutputs[j];
             const _outputSymbol = orderDetails.validOutputs.find(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1477,6 +1477,9 @@ const bundleOrders = (
     for (let i = 0; i < ordersDetails.length; i++) {
         const orderDetails = ordersDetails[i];
         const orderStruct = JSON.parse(ordersDetails[i].orderJSONString);
+        // exchange the "handleIo" to "handleIO"
+        orderStruct.handleIO = orderStruct.handleIo;
+        delete orderStruct.handleIo;
         for (let j = 0; j < orderStruct.validOutputs.length; j++) {
             const _output = orderStruct.validOutputs[j];
             const _outputSymbol = orderDetails.validOutputs.find(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1478,7 +1478,7 @@ const bundleOrders = (
         const orderDetails = ordersDetails[i];
         const orderStruct = JSON.parse(ordersDetails[i].orderJSONString);
         // exchange the "handleIo" to "handleIO" in case "handleIO" is not present in order json
-        if (orderStruct.handleIO === undefined || orderStruct.handleIO === null) {
+        if (orderStruct.handleIO === undefined) {
             orderStruct.handleIO = orderStruct.handleIo;
             delete orderStruct.handleIo;
         }

--- a/test/orders.test.js
+++ b/test/orders.test.js
@@ -203,4 +203,46 @@ describe("Test order details", async function () {
         ];
         assert.deepEqual(bundledResult, bundledExpected);
     });
+
+    it("should correctly handle handleIo/handleIO key", async function () {
+        const orderWithHandleIoKey = {
+            orderJSONString: "{\"owner\":\"0x0f47a0c7f86a615606ca315ad83c3e302b474bd6\",\"handleIo\":true,\"evaluable\":{\"interpreter\":\"0x1efd85e6c384fad9b80c6d508e9098eb91c4ed30\",\"store\":\"0x4ffc97bfb6dfce289f9b2a4083f5f5e940c8b88d\",\"expression\":\"0x224f9ca76a6f1b3414280bed0f68227c1b61f2b2\"},\"validInputs\":[{\"token\":\"0xc2132d05d31c914a87c6611c10748aeb04b58e8f\",\"decimals\":\"6\",\"vaultId\":\"0xdce98e3a7ee4b8b7ec1def4542b220083f8c3f0d569f142752cdc5bad6e14092\"}],\"validOutputs\":[{\"token\":\"0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270\",\"decimals\":\"18\",\"vaultId\":\"0xdce98e3a7ee4b8b7ec1def4542b220083f8c3f0d569f142752cdc5bad6e14092\"}]}",
+            id: "0x004349d76523bce3b6aeec93cf4c2a396b9cb71bc07f214e271cab363a0c89eb",
+            validInputs: [{
+                token: {
+                    id: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+                    decimals: 6,
+                    symbol: "USDT"
+                }
+            }],
+            validOutputs: [{
+                token: {
+                    id: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+                    decimals: 18,
+                    symbol: "WMATIC",
+                }
+            }]
+        };
+        const orderWithHandleIOKey = {
+            orderJSONString: "{\"owner\":\"0x0f47a0c7f86a615606ca315ad83c3e302b474bd6\",\"handleIO\":true,\"evaluable\":{\"interpreter\":\"0x1efd85e6c384fad9b80c6d508e9098eb91c4ed30\",\"store\":\"0x4ffc97bfb6dfce289f9b2a4083f5f5e940c8b88d\",\"expression\":\"0x224f9ca76a6f1b3414280bed0f68227c1b61f2b2\"},\"validInputs\":[{\"token\":\"0xc2132d05d31c914a87c6611c10748aeb04b58e8f\",\"decimals\":\"6\",\"vaultId\":\"0xdce98e3a7ee4b8b7ec1def4542b220083f8c3f0d569f142752cdc5bad6e14092\"}],\"validOutputs\":[{\"token\":\"0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270\",\"decimals\":\"18\",\"vaultId\":\"0xdce98e3a7ee4b8b7ec1def4542b220083f8c3f0d569f142752cdc5bad6e14092\"}]}",
+            id: "0x004349d76523bce3b6aeec93cf4c2a396b9cb71bc07f214e271cab363a0c89eb",
+            validInputs: [{
+                token: {
+                    id: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+                    decimals: 6,
+                    symbol: "USDT"
+                }
+            }],
+            validOutputs: [{
+                token: {
+                    id: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+                    decimals: 18,
+                    symbol: "WMATIC",
+                }
+            }]
+        };
+        const result1 = bundleOrders([orderWithHandleIoKey], false, false);
+        const result2 = bundleOrders([orderWithHandleIOKey], false, false);
+        assert.deepEqual(result1, result2);
+    });
 });

--- a/test/orders.test.js
+++ b/test/orders.test.js
@@ -73,7 +73,13 @@ describe("Test order details", async function () {
                 takeOrders: [{
                     id: order1.id,
                     takeOrder: {
-                        order: orderStruct1,
+                        order: {
+                            owner: orderStruct1.owner,
+                            handleIO: orderStruct1.handleIo,
+                            evaluable: orderStruct1.evaluable,
+                            validInputs: orderStruct1.validInputs,
+                            validOutputs: orderStruct1.validOutputs
+                        },
                         inputIOIndex: 0,
                         outputIOIndex: 0,
                         signedContext: []
@@ -90,7 +96,13 @@ describe("Test order details", async function () {
                 takeOrders: [{
                     id: order2.id,
                     takeOrder: {
-                        order: orderStruct2,
+                        order: {
+                            owner: orderStruct2.owner,
+                            handleIO: orderStruct2.handleIo,
+                            evaluable: orderStruct2.evaluable,
+                            validInputs: orderStruct2.validInputs,
+                            validOutputs: orderStruct2.validOutputs
+                        },
                         inputIOIndex: 1,
                         outputIOIndex: 0,
                         signedContext: []
@@ -107,7 +119,13 @@ describe("Test order details", async function () {
                 takeOrders: [{
                     id: order2.id,
                     takeOrder: {
-                        order: orderStruct2,
+                        order: {
+                            owner: orderStruct2.owner,
+                            handleIO: orderStruct2.handleIo,
+                            evaluable: orderStruct2.evaluable,
+                            validInputs: orderStruct2.validInputs,
+                            validOutputs: orderStruct2.validOutputs
+                        },
                         inputIOIndex: 0,
                         outputIOIndex: 1,
                         signedContext: []
@@ -130,7 +148,13 @@ describe("Test order details", async function () {
                     {
                         id: order1.id,
                         takeOrder: {
-                            order: orderStruct1,
+                            order: {
+                                owner: orderStruct1.owner,
+                                handleIO: orderStruct1.handleIo,
+                                evaluable: orderStruct1.evaluable,
+                                validInputs: orderStruct1.validInputs,
+                                validOutputs: orderStruct1.validOutputs
+                            },
                             inputIOIndex: 0,
                             outputIOIndex: 0,
                             signedContext: []
@@ -139,7 +163,13 @@ describe("Test order details", async function () {
                     {
                         id: order2.id,
                         takeOrder: {
-                            order: orderStruct2,
+                            order: {
+                                owner: orderStruct2.owner,
+                                handleIO: orderStruct2.handleIo,
+                                evaluable: orderStruct2.evaluable,
+                                validInputs: orderStruct2.validInputs,
+                                validOutputs: orderStruct2.validOutputs
+                            },
                             inputIOIndex: 0,
                             outputIOIndex: 1,
                             signedContext: []
@@ -157,7 +187,13 @@ describe("Test order details", async function () {
                 takeOrders: [{
                     id: order2.id,
                     takeOrder: {
-                        order: orderStruct2,
+                        order: {
+                            owner: orderStruct2.owner,
+                            handleIO: orderStruct2.handleIo,
+                            evaluable: orderStruct2.evaluable,
+                            validInputs: orderStruct2.validInputs,
+                            validOutputs: orderStruct2.validOutputs
+                        },
                         inputIOIndex: 1,
                         outputIOIndex: 0,
                         signedContext: []


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
order json struct read from sg has the key `handleIo` which is not the correct key in the arb contract abi, the correct key is `handleIO`, this results in a different order struct submitted by the bot and as a result order book ends up recalculating the hash incorrectly.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
echange the `handleIo` key to `handleIO`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
