### PR TITLE
forking module

### DIFF
--- a/.github/workflows/standard-test.yaml
+++ b/.github/workflows/standard-test.yaml
@@ -23,6 +23,8 @@ jobs:
       
       - name: Run Tests
         run: nix develop -c npm run unit-test
+        env: 
+          TEST_POLYGON_RPC: ${{ secrets.CI_DEPLOY_POLYGON_RPC_URL }}
   
   e2e-test:
     name: e2e fork test

--- a/src/abis.js
+++ b/src/abis.js
@@ -4,7 +4,8 @@
 const erc20Abi = [
     "event Transfer(address indexed from, address indexed to, uint256 value)",
     "function symbol() public view returns (string memory)",
-    "function transfer(address to, uint256 amount) external returns (bool)"
+    "function transfer(address to, uint256 amount) external returns (bool)",
+    "function balanceOf(address account) external view returns (uint256)"
 ];
 
 /**

--- a/src/fork.js
+++ b/src/fork.js
@@ -1,0 +1,87 @@
+const ethers = require("ethers");
+const { HardhatNode } = require("hardhat/internal/hardhat-network/provider/node");
+
+/**
+ * Creates a fork evm from the given rpc at the given block number
+ * @param {string} jsonRpcUrl - the rpc url
+ * @param {number} block - the block details
+ * @param {number} chainId - the network chain id
+ */
+async function createFork(jsonRpcUrl, block, chainId) {
+    // hardhat node config, this fields are default,
+    // except forkConfig, blockGasLimit, networkId, chainId and initialDate
+    const hardhatNodeConfig = {
+        automine: true,
+        blockGasLimit: block.gasLimit,
+        genesisAccounts: [],
+        mempoolOrder: "priority",
+        hardfork: "shanghai",
+        chainId,
+        networkId: chainId,
+        initialDate: new Date(),
+        forkConfig: {
+            jsonRpcUrl,
+            blockNumber: block.number,
+        },
+        forkCachePath: undefined,
+        coinbase: "0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e",
+        chains: new Map(),
+        allowBlocksWithSameTimestamp: false
+    };
+    const [common, hardhatNode] = await HardhatNode.create(hardhatNodeConfig);
+    return [block, hardhatNodeConfig, common, hardhatNode];
+}
+
+class Fork {
+    block;
+    common;
+    hardhatNode;
+    hardhatNodeConfig;
+    constructor() {}
+
+    /**
+     * Creates a fork evm from the given rpc at the given block number
+     * @param {string} rpcUrl - the rpc url
+     * @param {number} block - the block details
+     * @param {number} chainId - the network's chain id
+     * @returns a Fork instance
+     */
+    static async create(rpcUrl, block, chainId) {
+        const fork = new Fork();
+        [
+            fork.block,
+            fork.hardhatNodeConfig,
+            fork.common,
+            fork.hardhatNode,
+        ] = await createFork(rpcUrl, block, chainId);
+        return fork;
+    }
+
+    /**
+     * Estimates gas for a given tx
+     * @param tx - The raw transaction
+     */
+    async estimateGas({ to, from, data, gasPrice }) {
+        if (!to || !ethers.utils.isAddress(to)) throw "invalid to address";
+        if (!data || !ethers.utils.isBytesLike(data)) throw "invalid data";
+        if (!from || !ethers.utils.isAddress(from)) throw "invalid from address";
+
+        const tx = {
+            to: Buffer.from(ethers.utils.arrayify(to)),
+            from: Buffer.from(ethers.utils.arrayify(from)),
+            data: Buffer.from(ethers.utils.arrayify(data)),
+            gasLimit: this.hardhatNode.getBlockGasLimit(),
+            value: 0n,
+        };
+        if (gasPrice && ethers.BigNumber.isBigNumber(gasPrice)) tx.gasPrice = gasPrice.toBigInt();
+        return ethers.BigNumber.from(
+            (await this.hardhatNode.estimateGas(tx, "pending")).estimation
+        );
+    }
+
+}
+
+module.exports = {
+    createFork,
+    Fork
+};

--- a/src/fork.js
+++ b/src/fork.js
@@ -8,7 +8,7 @@ const { HardhatNode } = require("hardhat/internal/hardhat-network/provider/node"
  * @param {number} chainId - the network chain id
  */
 async function createFork(jsonRpcUrl, block, chainId) {
-    // hardhat node config, this fields are default,
+    // hardhat node config, the fields are default,
     // except forkConfig, blockGasLimit, networkId, chainId and initialDate
     const hardhatNodeConfig = {
         automine: true,

--- a/test/fork.test.js
+++ b/test/fork.test.js
@@ -1,0 +1,52 @@
+const { assert } = require("chai");
+const { ethers } = require("ethers");
+const { Fork } = require("../src/fork");
+const { erc20Abi } = require("../src/abis");
+
+describe("Test forking evm", async function () {
+    it("should fork from rpc", async function () {
+        const provider = new ethers.providers.JsonRpcProvider(process?.env?.TEST_POLYGON_RPC);
+
+        const blockNumber = await provider.getBlockNumber();
+        const block = await provider.getBlock(blockNumber);
+
+        const fork = await Fork.create(process?.env?.TEST_POLYGON_RPC, block, 137);
+        const forkLastBlock = await fork.hardhatNode.getLatestBlock();
+
+        assert.deepEqual(BigInt(block.difficulty), forkLastBlock.header.difficulty);
+        assert.deepEqual(block.extraData, ethers.utils.hexlify(forkLastBlock.header.extraData));
+        assert.deepEqual(block.gasLimit.toBigInt(), forkLastBlock.header.gasLimit);
+        assert.deepEqual(block.gasUsed.toBigInt(), forkLastBlock.header.gasUsed);
+        assert.deepEqual(BigInt(block.number), forkLastBlock.header.number);
+        assert.deepEqual(BigInt(block.timestamp), forkLastBlock.header.timestamp);
+        assert.deepEqual(block.parentHash, ethers.utils.hexlify(forkLastBlock.header.parentHash));
+        assert.deepEqual(block.baseFeePerGas.toBigInt(), forkLastBlock.header.baseFeePerGas);
+    });
+
+    it("should return reliable gas estimation", async function () {
+        const provider = new ethers.providers.JsonRpcProvider(process?.env?.TEST_POLYGON_RPC);
+
+        const blockNumber = await provider.getBlockNumber();
+        const block = await provider.getBlock(blockNumber);
+
+        const fork = await Fork.create(process?.env?.TEST_POLYGON_RPC, block, 137);
+
+        const erc20interface = new ethers.utils.Interface(erc20Abi);
+        const from = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+        const to = "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"; // wmatic
+        const balanceOfCalldata = erc20interface.encodeFunctionData(
+            "balanceOf",
+            ["0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97"]
+        );
+        const balanceOfRpcGas = await provider.estimateGas({ from, to, data: balanceOfCalldata });
+        const balanceOfForkGas = await fork.estimateGas({ to, from, data: balanceOfCalldata });
+
+        assert.ok(balanceOfRpcGas.eq(balanceOfForkGas));
+
+        const symbolCalldata = erc20interface.encodeFunctionData("symbol", []);
+        const symbolRpcGas = await provider.estimateGas({ from, to, data: symbolCalldata });
+        const symbolForkGas = await fork.estimateGas({ to, from, data: symbolCalldata });
+
+        assert.ok(symbolRpcGas.eq(symbolForkGas));
+    });
+});

--- a/test/fork.test.js
+++ b/test/fork.test.js
@@ -13,14 +13,14 @@ describe("Test forking evm", async function () {
         const fork = await Fork.create(process?.env?.TEST_POLYGON_RPC, block, 137);
         const forkLastBlock = await fork.hardhatNode.getLatestBlock();
 
-        assert.deepEqual(BigInt(block.difficulty), forkLastBlock.header.difficulty);
-        assert.deepEqual(block.extraData, ethers.utils.hexlify(forkLastBlock.header.extraData));
-        assert.deepEqual(block.gasLimit.toBigInt(), forkLastBlock.header.gasLimit);
-        assert.deepEqual(block.gasUsed.toBigInt(), forkLastBlock.header.gasUsed);
-        assert.deepEqual(BigInt(block.number), forkLastBlock.header.number);
-        assert.deepEqual(BigInt(block.timestamp), forkLastBlock.header.timestamp);
-        assert.deepEqual(block.parentHash, ethers.utils.hexlify(forkLastBlock.header.parentHash));
-        assert.deepEqual(block.baseFeePerGas.toBigInt(), forkLastBlock.header.baseFeePerGas);
+        assert.equal(BigInt(block.difficulty), forkLastBlock.header.difficulty);
+        assert.equal(block.extraData, ethers.utils.hexlify(forkLastBlock.header.extraData));
+        assert.equal(block.gasLimit.toBigInt(), forkLastBlock.header.gasLimit);
+        assert.equal(block.gasUsed.toBigInt(), forkLastBlock.header.gasUsed);
+        assert.equal(BigInt(block.number), forkLastBlock.header.number);
+        assert.equal(BigInt(block.timestamp), forkLastBlock.header.timestamp);
+        assert.equal(block.parentHash, ethers.utils.hexlify(forkLastBlock.header.parentHash));
+        assert.equal(block.baseFeePerGas.toBigInt(), forkLastBlock.header.baseFeePerGas);
     });
 
     it("should return reliable gas estimation", async function () {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
part of implementation steps for #101 
implement a module that can fork an evm from rpc url as well as method for estimating gas for tx
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
using hardhat node module, a fork can be instantiated modularly from a rpc at a specific block number.
hardhat node provides reliable gas estimation logic that can be used later on to finda gas estimation for an `arb()` tx
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
