### PR TITLE
zero gas estimate bug

### DIFF
--- a/src/gas.ts
+++ b/src/gas.ts
@@ -1,8 +1,8 @@
 import { ChainId } from "sushi";
 import { BigNumber } from "ethers";
 import { getQuoteConfig } from "./utils";
+import { publicActionsL2 } from "viem/op-stack";
 import { encodeFunctionData, multicall3Abi, toHex } from "viem";
-import { publicActionsL2, walletActionsL2 } from "viem/op-stack";
 import { BotConfig, BundledOrders, OperationState, RawTx, ViemClient } from "./types";
 import { ArbitrumNodeInterfaceAbi, ArbitrumNodeInterfaceAddress, OrderbookQuoteAbi } from "./abis";
 
@@ -32,9 +32,7 @@ export async function estimateGasCost(
     };
     if (config.isSpecialL2) {
         try {
-            const l1Signer_ = l1Signer
-                ? l1Signer
-                : signer.extend(walletActionsL2()).extend(publicActionsL2());
+            const l1Signer_ = l1Signer ? l1Signer : signer.extend(publicActionsL2());
             if (typeof l1GasPrice !== "bigint") {
                 l1GasPrice = (await l1Signer_.getL1BaseFee()) as bigint;
             }

--- a/src/modes/interOrderbook.ts
+++ b/src/modes/interOrderbook.ts
@@ -214,6 +214,20 @@ export async function dryrun({
             return Promise.reject(result);
         }
     }
+    if (gasLimit.isZero()) {
+        spanAttributes["stage"] = 2;
+        spanAttributes["isNodeError"] = true;
+        spanAttributes["error"] =
+            "Failed to estimated gas, rpc returned 0 for gasEstimate call without rejection";
+        spanAttributes["rawtx"] = JSON.stringify(
+            {
+                ...rawtx,
+                from: signer.account.address,
+            },
+            withBigintSerializer,
+        );
+        return Promise.reject(result);
+    }
     rawtx.gas = gasLimit.toBigInt();
 
     // if reached here, it means there was a success and found opp

--- a/src/modes/interOrderbook.ts
+++ b/src/modes/interOrderbook.ts
@@ -1,9 +1,9 @@
 import { orderbookAbi } from "../abis";
 import { estimateGasCost } from "../gas";
-import { BaseError, PublicClient } from "viem";
 import { BigNumber, Contract, ethers } from "ethers";
 import { containsNodeError, errorSnapshot } from "../error";
 import { getBountyEnsureRainlang, parseRainlang } from "../task";
+import { BaseError, ExecutionRevertedError, PublicClient } from "viem";
 import { BotConfig, BundledOrders, ViemClient, DryrunResult, SpanAttrs } from "../types";
 import {
     ONE18,
@@ -175,6 +175,12 @@ export async function dryrun({
             gasLimit = ethers.BigNumber.from(estimation.gas)
                 .mul(config.gasLimitMultiplier)
                 .div(100);
+            if (gasLimit.isZero()) {
+                throw new ExecutionRevertedError({
+                    message:
+                        "Failed to estimated gas, rpc returned 0 for gasEstimate call without rejection",
+                });
+            }
             rawtx.gas = gasLimit.toBigInt();
             gasCost = gasLimit.mul(gasPrice).add(estimation.l1Cost);
             task.evaluable.bytecode = await parseRainlang(
@@ -213,20 +219,6 @@ export async function dryrun({
             }
             return Promise.reject(result);
         }
-    }
-    if (gasLimit.isZero()) {
-        spanAttributes["stage"] = 2;
-        spanAttributes["isNodeError"] = true;
-        spanAttributes["error"] =
-            "Failed to estimated gas, rpc returned 0 for gasEstimate call without rejection";
-        spanAttributes["rawtx"] = JSON.stringify(
-            {
-                ...rawtx,
-                from: signer.account.address,
-            },
-            withBigintSerializer,
-        );
-        return Promise.reject(result);
     }
     rawtx.gas = gasLimit.toBigInt();
 

--- a/src/modes/intraOrderbook.ts
+++ b/src/modes/intraOrderbook.ts
@@ -225,6 +225,20 @@ export async function dryrun({
             return Promise.reject(result);
         }
     }
+    if (gasLimit.isZero()) {
+        spanAttributes["stage"] = 2;
+        spanAttributes["isNodeError"] = true;
+        spanAttributes["error"] =
+            "Failed to estimated gas, rpc returned 0 for gasEstimate call without rejection";
+        spanAttributes["rawtx"] = JSON.stringify(
+            {
+                ...rawtx,
+                from: signer.account.address,
+            },
+            withBigintSerializer,
+        );
+        return Promise.reject(result);
+    }
     rawtx.gas = gasLimit.toBigInt();
 
     // if reached here, it means there was a success and found opp

--- a/src/modes/routeProcessor.ts
+++ b/src/modes/routeProcessor.ts
@@ -498,7 +498,7 @@ export async function findOppWithRetries({
             // ie its maxInput is the greatest
             const prom = allPromises[i];
             if (prom.status === "fulfilled") {
-                if (!choice || choice.maximumInput!.lt(prom.value.value!.maximumInput!)) {
+                if (!choice || choice.estimatedProfit.lt(prom.value.value!.estimatedProfit)) {
                     // record the attributes of the choosing one
                     for (const attrKey in prom.value.spanAttributes) {
                         spanAttributes[attrKey] = prom.value.spanAttributes[attrKey];

--- a/src/modes/routeProcessor.ts
+++ b/src/modes/routeProcessor.ts
@@ -281,6 +281,21 @@ export async function dryrun({
                 return Promise.reject(result);
             }
         }
+        if (gasLimit.isZero()) {
+            spanAttributes["stage"] = 2;
+            spanAttributes["isNodeError"] = true;
+            spanAttributes["error"] =
+                "Failed to estimated gas, rpc returned 0 for gasEstimate call without rejection";
+            spanAttributes["rawtx"] = JSON.stringify(
+                {
+                    ...rawtx,
+                    from: signer.account.address,
+                },
+                withBigintSerializer,
+            );
+            result.reason = RouteProcessorDryrunHaltReason.NoOpportunity;
+            return Promise.reject(result);
+        }
         rawtx.gas = gasLimit.toBigInt();
 
         // if reached here, it means there was a success and found opp

--- a/test/gas.test.ts
+++ b/test/gas.test.ts
@@ -1,8 +1,8 @@
 import { assert } from "chai";
+import { ChainId } from "sushi";
 import { orderPairObject1 } from "./data";
 import { OperationState, ViemClient } from "../src/types";
 import { estimateGasCost, getGasPrice, getL1Fee, getQuoteGas, getTxFee } from "../src/gas";
-import { ChainId } from "sushi";
 
 describe("Test gas", async function () {
     it("should estimate gas correctly for L1 and L2 chains", async function () {
@@ -80,7 +80,9 @@ describe("Test gas", async function () {
 
     it("should get tx fee", async function () {
         // mock config and receipt
-        const config = {} as any;
+        const config = {
+            chain: { id: 137 },
+        } as any;
         const receipt = {
             effectiveGasPrice: 10n,
             gasUsed: 5n,
@@ -102,6 +104,7 @@ describe("Test gas", async function () {
         const l1GasPrice = 2n;
         // mock config and viem client
         const config = {
+            chain: { id: 137 },
             isSpecialL2: false,
             gasPriceMultiplier: 100n,
             viemClient: { getGasPrice: async () => gasPrice },


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
some rpcs return 0 for gas estimate without actually rejecting the rpc call
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
explicitly check retruned gas estimate and bail if it is 0
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
