### PR TITLE
fix gas price fetcher

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -620,9 +620,6 @@ export const main = async (argv: any, version?: string) => {
         }
     });
 
-    // periodically fetch and set gas price in state (once every 20 seconds)
-    setInterval(() => getGasPrice(config, state), 20_000);
-
     const lastReadOrdersMap = options.subgraph.map((v) => ({
         sg: v,
         skip: 0,
@@ -704,6 +701,7 @@ export const main = async (argv: any, version?: string) => {
                 const bundledOrders = prepareOrdersForRound(orderbooksOwnersProfileMap, true);
                 await rotateProviders(config, update);
                 roundSpan.setAttribute("details.rpc", config.rpc);
+                await getGasPrice(config, state);
                 const roundResult = await arbRound(
                     tracer,
                     roundCtx,

--- a/src/processOrders.ts
+++ b/src/processOrders.ts
@@ -1,11 +1,11 @@
 import { ChainId } from "sushi";
 import { findOpp } from "./modes";
-import { getQuoteGas } from "./gas";
 import { PublicClient } from "viem";
 import { Token } from "sushi/currency";
 import { quoteSingleOrder } from "./order";
 import { createViemClient } from "./config";
 import { arbAbis, orderbookAbi } from "./abis";
+import { getGasPrice, getQuoteGas } from "./gas";
 import { getSigner, handleTransaction } from "./tx";
 import { privateKeyToAccount } from "viem/accounts";
 import { BigNumber, Contract, ethers } from "ethers";
@@ -564,6 +564,7 @@ export async function processPair(args: {
     }
 
     // record gas price for otel
+    await getGasPrice(config, state);
     spanAttributes["details.gasPrice"] = state.gasPrice.toString();
     if (state.l1GasPrice) {
         spanAttributes["details.gasPriceL1"] = state.l1GasPrice.toString();

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,7 +96,6 @@ export type BundledOrders = {
 
 export type TakeOrderDetails = {
     id: string;
-    // active: boolean;
     quote?: {
         maxOutput: BigNumber;
         ratio: BigNumber;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
getting gas price by using setInterval, causes minimal memory leak since the config obj client property rotates but setInterval keeps a ref to it.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Dont use setInterval for gtetting gas price
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the gas price update behavior to fetch the latest rate immediately before processing orders, ensuring more current pricing and improved telemetry.

- **Chores**
  - Removed outdated code comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->